### PR TITLE
Filter `teis` with duplicate patient number

### DIFF
--- a/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
+++ b/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
@@ -97,7 +97,7 @@ workflows:
         condition_type: js_expression
         condition_label: has-teis
         condition_expression: |
-          state.teis.length > 0 && !state.errors
+          state.uniqueTeis.length > 0 && !state.errors
 
         enabled: true
       Create-Patients->Update-Teis:

--- a/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
+++ b/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
@@ -67,6 +67,13 @@ workflows:
         credential: aleksa@openfn.org-openmrs-admin
         body:
           path: workflows/wf1/3-create-patients.js
+      
+      Alert-Admin:
+        name: Alert Admin
+        adaptor: '@openfn/language-common@latest'
+        credential: null
+        body:
+          path: workflows/wf1/3-alert-admin.js
 
       Update-Teis:
         name: Update Teis
@@ -98,6 +105,15 @@ workflows:
         condition_label: has-teis
         condition_expression: |
           state.uniqueTeis.length > 0 && !state.errors
+
+        enabled: true
+      Get-Teis-and-Locations->Alert-Admin:
+        source_job: Get-Teis-and-Locations
+        target_job: Alert-Admin
+        condition_type: js_expression
+        condition_label: has-duplicate-patients
+        condition_expression: |
+          state.duplicatePatients.length > 0 && !state.errors
 
         enabled: true
       Create-Patients->Update-Teis:

--- a/workflows/wf1/2-get-teis-and-locations.js
+++ b/workflows/wf1/2-get-teis-and-locations.js
@@ -1,34 +1,68 @@
+const findDuplicatePatient = teis => {
+  const seen = new Map();
+  const duplicates = new Set();
+
+  teis.forEach(tei => {
+    const patientNumber = tei.attributes.find(
+      attr => attr.code === 'patient_number'
+    )?.value;
+
+    if (seen.get(patientNumber)) {
+      duplicates.add(patientNumber);
+    } else {
+      seen.set(patientNumber, tei);
+    }
+  });
+
+  return duplicates;
+};
 // Get teis that are "active" in the target program
-get(
-  'tracker/trackedEntities',
-  {
-    orgUnit: $.orgUnit, //'OPjuJMZFLop',
-    program: $.program, //'w9MSPn5oSqp',
-    programStatus: 'ACTIVE',
-    updatedAfter: $.cursor,
-    skipPaging: true,
-  },
-  {},
-  state => {
-    // console.log('TEIs found ::', JSON.stringify(state.data.instances, null,2))
-    const teis = state.data.instances.filter(
-      tei => tei.updatedAt >= state.cursor
-    );
+get('tracker/trackedEntities', {
+  orgUnit: $.orgUnit, //'OPjuJMZFLop',
+  program: $.program, //'w9MSPn5oSqp',
+  programStatus: 'ACTIVE',
+  updatedAfter: $.cursor,
+  skipPaging: true,
+});
 
-    console.log(
-      '# of TEIs found before filter ::',
-      state.data.instances.length
-    );
-    console.log('# of TEIs to migrate to OMRS ::', teis.length);
+fn(state => {
+  console.log('# of TEIs found before filter ::', state.data.instances.length);
+  const uniqueTeis = [];
+  const duplicatePatients = [];
+  const missingPatientNumber = [];
 
-    return {
-      ...state,
-      data: {},
-      references: [],
-      teis,
-    };
-  }
-);
+  const filteredTeis = state.data.instances.filter(
+    tei => tei.updatedAt >= state.cursor
+  );
+
+  console.log('Filtered TEIs ::', filteredTeis.length);
+  const duplicateIds = findDuplicatePatient(filteredTeis);
+
+  filteredTeis.forEach(tei => {
+    const patientNumber = tei.attributes.find(
+      attr => attr.code === 'patient_number'
+    )?.value;
+
+    if (!patientNumber) {
+      missingPatientNumber.push(tei);
+    } else if (duplicateIds.has(patientNumber)) {
+      duplicatePatients.push(tei);
+    } else {
+      uniqueTeis.push(tei);
+    }
+  });
+
+  console.log('# of Unique TEIs to migrate to OMRS ::', uniqueTeis.length);
+  // return { uniqueTeis, duplicatePatients, filteredTeis, missingPatientNumber };
+  return {
+    ...state,
+    data: {},
+    references: [],
+    uniqueTeis,
+    duplicatePatients,
+    missingPatientNumber,
+  };
+});
 
 get('optionGroups/kdef7pUey9f', {
   fields: 'id,displayName,options[id,displayName,code]',

--- a/workflows/wf1/2-get-teis-and-locations.js
+++ b/workflows/wf1/2-get-teis-and-locations.js
@@ -37,6 +37,7 @@ fn(state => {
 
   console.log('Filtered TEIs ::', filteredTeis.length);
   const duplicateIds = findDuplicatePatient(filteredTeis);
+  console.log('Duplicate Patient Numbers::', [...duplicateIds]);
 
   filteredTeis.forEach(tei => {
     const patientNumber = tei.attributes.find(

--- a/workflows/wf1/3-alert-admin.js
+++ b/workflows/wf1/3-alert-admin.js
@@ -1,0 +1,6 @@
+fn(state => {
+  util.throwError('DUPLICATE_PATIENT_NUMBERS', {
+    description: 'Found TIEs with duplicate patient numbers',
+    duplicates: state.duplicatePatients,
+  });
+});

--- a/workflows/wf1/workflow.json
+++ b/workflows/wf1/workflow.json
@@ -35,8 +35,8 @@
             },
             {
                 "id": "update-teis",
-                "adaptor": "openmrs",
-                "configuration": "../tmp/openmrs-creds.json",
+                "adaptor": "dhis2",
+                "configuration": "../tmp/dhis2-creds.json",
                 "expression": "4-update-teis.js"
             }
         ]

--- a/workflows/wf1/workflow.json
+++ b/workflows/wf1/workflow.json
@@ -5,9 +5,6 @@
                 "id": "fetch-metadata",
                 "adaptor": "http",
                 "expression": "1-fetch-metadata.js",
-                "state": {
-                    "manualCursor": "2024-06-04"
-                },
                 "next": {
                     "get-teis": "!state.errors"
                 }
@@ -18,7 +15,7 @@
                 "configuration": "../tmp/dhis2-creds.json",
                 "expression": "2-get-teis-and-locations.js",
                 "next": {
-                    "create-patients": "!state.errors"
+                    "create-patients": "state.uniqueTeis.length > 0 && !state.errors"
                 }
             },
             {
@@ -27,7 +24,7 @@
                 "configuration": "../tmp/openmrs-creds.json",
                 "expression": "3-create-patients.js",
                 "next": {
-                    "update-teis": true
+                    "update-teis": "!state.errors"
                 }
             },
             {

--- a/workflows/wf1/workflow.json
+++ b/workflows/wf1/workflow.json
@@ -15,8 +15,14 @@
                 "configuration": "../tmp/dhis2-creds.json",
                 "expression": "2-get-teis-and-locations.js",
                 "next": {
+                    "alert-admin": "state.duplicatePatients.length > 0 && !state.errors",
                     "create-patients": "state.uniqueTeis.length > 0 && !state.errors"
                 }
+            },
+            {
+                "id": "alert-admin",
+                "adaptor": "common",
+                "expression": "3-alert-admin.js"
             },
             {
                 "id": "create-patients",


### PR DESCRIPTION
**Description**

After fetching `Teis` from DHIS2, separate `teis` with duplicate patient number for alerting the admin

**Details**
- Add a `findDuplicatePatient` function which return a set of duplicates patient numbers
- Filter `teis` to return a list of `uniqueTeis`, `duplicatePatients` and `missingPatientNumber`
- Update `create-patient` step to use `state.uniqueTeis`
- Add `alert-admin` step which throws an error with the list of `state.duplicatePatients`
- Update `spec.yaml` for `msf-lime-mosul` project

**Issue**
- #95 