### PR TITLE
Reduce encounters object and update education mapping

### DIFF
--- a/workflows/wf2/3-get-encounters.js
+++ b/workflows/wf2/3-get-encounters.js
@@ -38,7 +38,6 @@ fn(state => {
     'Total # of encounters fetched: ',
     state.allResponse?.entry?.length
   );
-  state.encounterUuids = state.allResponse?.entry?.map(p => p.resource.id);
   state.patientUuids = [
     ...new Set(
       state.allResponse?.entry?.map(p =>
@@ -97,14 +96,32 @@ fn(state => {
     references,
     allResponse,
     patientUuids,
+    patients,
     ...next
   } = state;
 
   if (next.encounters?.length) {
+    next.encounters = next.encounters.map(
+      ({ uuid, patient, obs, form, encounterDatetime }) => ({
+        uuid,
+        patient,
+        obs,
+        form,
+        encounterDatetime,
+      })
+    );
     console.log(next.encounters.length, '# of new encounters to sync to dhis2');
   } else {
     console.log('No encounters found for cursor: ', next.cursor);
   }
-
+  next.allEncounters = next.allEncounters.map(
+    ({ uuid, patient, obs, form, encounterDatetime }) => ({
+      uuid,
+      patient,
+      obs,
+      form,
+      encounterDatetime,
+    })
+  );
   return next;
 });

--- a/workflows/wf2/6-create-events.js
+++ b/workflows/wf2/6-create-events.js
@@ -5,9 +5,9 @@ create(
     events: state => {
       console.log(
         'Creating events for: ',
-        JSON.stringify(state.encountersMapping, null, 2)
+        JSON.stringify(state.eventsMapping, null, 2)
       );
-      return state.encountersMapping;
+      return state.eventsMapping;
     },
   },
   {
@@ -47,8 +47,7 @@ fn(state => {
     // Lighten state by removing unused properties
     formMaps,
     optionSetKey,
-    encountersMapping,
-    encounterUuids,
+    eventsMapping,
     formUuids,
     references,
     ...next
@@ -114,7 +113,9 @@ fn(state => {
           attributes: [
             {
               attribute: 'Dggll4f9Efj', //education
-              value: answer.value.display, //map to DHIS2 Option Code in optsMap 
+              value: optsMap.find(
+                o => o['value.display - Answers'] === answer.value.display
+              )?.['DHIS2 Option Code'], //map to DHIS2 Option Code in optsMap
             },
           ],
         };
@@ -123,19 +124,6 @@ fn(state => {
     .filter(Boolean)
     .flat();
 
-// {
-//       "DHIS2 DE UID": "Dggll4f9Efj",
-//       "DHIS2 DE full name": "Education",
-//       "DHIS2 Option Code": "illiterate",
-//       "DHIS2 Option Set UID": "tDxpzAER9vr",
-//       "DHIS2 Option Set name": "GL - Education",
-//       "DHIS2 Option UID": "sIF0jNg9LOn",
-//       "DHIS2 Option name": "Illiterate",
-//       "OptionSet name": "Education - MH",
-//       "answerMappingUid": "f49d8262-d0f2-4a99-93c5-4533943663d3-tDxpzAER9vr",
-//       "value.display - Answers": "Illiterate",
-//       "value.uuid - External ID": "f49d8262-d0f2-4a99-93c5-4533943663d3"
-//     },
   return {
     ...next,
     teisToUpdate: [...genderUpdated, ...educationUpdated],


### PR DESCRIPTION
**Description**
This PR reduces `state.allEncounters` and `state.encounters` object keys by mapping only the keys we need in downstream jobs. And also update `create-events` mapping  to use the correct mapping (`state.eventsMapping`) and updated the education mapping to use `DHIS2 Option Code`

**Issue**
- #119 